### PR TITLE
Added brew lib and include folders for Mac OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,13 @@
             "link_settings": {
                 "libraries": ["-lmcrypt"]
             },
-            "include_dirs": ["<!(node -e \"require('nan')\")"]
+            "include_dirs": ["<!(node -e \"require('nan')\")"],
+            'conditions': [
+                ['OS=="mac"', {
+                    'include_dirs': ['/usr/local/include'],
+                    'library_dirs': ['/usr/local/lib'],
+                }],
+            ]
         }
     ]
 }


### PR DESCRIPTION
Trying to `npm install` on a Mac right now does not work, even with mcrypt installed with `brew`, because the `build.gpy` doesn't know where to find the header file for mcrypt.

```
  CXX(target) Release/obj.target/rijndael/src/rijndael.o
../src/rijndael.cc:9:10: fatal error: 'mcrypt.h' file not found
#include <mcrypt.h>
         ^
1 error generated.
make: *** [Release/obj.target/rijndael/src/rijndael.o] Error 1
```

Adding this conditional to the `build.gyp` lets me successfully build. Tested on Mac OS X 10.11 Beta with mcrypt-2.6.8 installed via `brew`.