### PR TITLE
Remove libmcrypt as an external dependency and use the submodule by tugrul

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/libmcrypt"]
+	path = lib/libmcrypt
+	url = git@github.com:tugrul/libmcrypt-gyp.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,16 +2,15 @@
     "targets": [
         {
             "target_name": "rijndael",
-            "sources": ["src/rijndael.cc"],
-            "link_settings": {
-                "libraries": ["-lmcrypt"]
-            },
-            "include_dirs": ["<!(node -e \"require('nan')\")"],
-            'conditions': [
-                ['OS=="mac"', {
-                    'include_dirs': ['/usr/local/include'],
-                    'library_dirs': ['/usr/local/lib'],
-                }],
+            "dependencies": [
+                "lib/libmcrypt/libmcrypt.gyp:libmcrypt",
+            ],
+            "sources": [
+                "src/rijndael.cc"
+            ],
+            "include_dirs": [
+                "lib/libmcrypt/include/",
+                "<!(node -e \"require('nan')\")"
             ]
         }
     ]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "compatibility"
   ],
   "dependencies": {
-    "nan": "~1.5.0"
+    "nan": "^1.9.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/src/rijndael.cc
+++ b/src/rijndael.cc
@@ -6,7 +6,7 @@
 // dependency
 #include <string.h>
 #include <stdlib.h>
-#include <mcrypt.h>
+#include "mcrypt.h"
 
 using namespace v8;
 using namespace node;


### PR DESCRIPTION
This way there's no external dependency to build on all platforms.
This also fixes https://github.com/skeggse/node-rijndael/issues/12
